### PR TITLE
Direct Wikipedia search

### DIFF
--- a/www/templates/person_sidebar_extra_links.tpl
+++ b/www/templates/person_sidebar_extra_links.tpl
@@ -12,7 +12,7 @@
   </li>
 
   <li class="identity_li small">
-    <a href="http://www.google.ro/search?hl=ro&q={$name}+site:wikipedia.org&btnI=Mă Simt Norocos&meta=lr%3Dlang_ro">
+    <a href="https://ro.wikipedia.org/w/index.php?search={$name}&title=Special%3AC%C4%83utare">
       Caută pe Wikipedia
     </a>
   </li>


### PR DESCRIPTION
Search ro.wikipedia directly instead of going through Google. This avoids weird behavior like searching for "Razvan Mironescu" and ending up with "Mihai Razvan Ungureanu".

The URL goes directly to the page if it exists, otherwise shows search results.

This is linked to Issue #68
