### PR TITLE
Îmbunătățirea hărților de pe paginile colegiilor electorale

### DIFF
--- a/www/js/politica.js
+++ b/www/js/politica.js
@@ -1053,6 +1053,7 @@ ec.loadCartoDb = function () {
         var pollLayer = setInterval(function () {
           try {
             layers[1].setCartoCSS(cartoCSS);
+            gmap.setZoom(gmap.getZoom() + 1);
             clearInterval(pollLayer);
           } catch (e) {
             // the layer is not yet available

--- a/www/person.php
+++ b/www/person.php
@@ -164,6 +164,7 @@ if ($college_name) {
   $t->assign('college_name', $college_name);
 
   $t->assign("pc_county_short", getCollegeCountyShort($college_name));
+  $t->assign("pc_county_id", getCollegeCountyId($college_name));
   $t->assign("pc_number", getCollegeNumber($college_name));
   $t->assign("pc_id", startsWith($college_name, "D") ? 15 : 14);
 

--- a/www/styles.css
+++ b/www/styles.css
@@ -857,6 +857,11 @@ a.new_link:hover {
   width: 960px;
 }
 
+.identity #cartoDb {
+  width: 290px;
+  height: 150px;
+}
+
 
 /* --------------------------- pretty button ---------------*/
 .button, .button span {

--- a/www/templates/electoral_college.tpl
+++ b/www/templates/electoral_college.tpl
@@ -28,12 +28,12 @@ clickHeatSite = 'hartapoliticii';clickHeatGroup = 'electoral_college';clickHeatS
             [jud_id = ##county## ] {
               [col_nr = ##number##] {
                 polygon-opacity: 0.6; 
-                line-width: 1
+                line-width: 2;
               }
             }
           }
-          {/literal}
         </script>
+        {/literal}
     {/if}
     <table width="970" style="margin-top:12px">
       <tr>

--- a/www/templates/person_sidebar_electoral_college.tpl
+++ b/www/templates/person_sidebar_electoral_college.tpl
@@ -4,10 +4,28 @@
   Reprezentant {$college_name}
 </div>
 
-<iframe seamless="seamless"
-        scrolling="no" frameboder="0"
-        style="width: 290px; height: 150px; border: 5px solid #eee;"
-        src="http://www.politicalcolours.ro/integrate.html?id={$pc_id}&p1={$pc_county_short}&p2={$pc_number}"></iframe>
+<div id="cartoDb" data-name="{$college_name}" data-county="{$pc_county_id}" data-number="{$pc_number}"></div>
+{literal}
+<script id="cartoCSS" type="text/html">
+  ###type##_2008 {
+    polygon-fill: #3E7BB6;
+    polygon-opacity: 0.1;
+    line-width: 1;
+    line-color: #FFF;
+    line-opacity: 1;
+    polygon-comp-op: src-over;
+    [jud_id = ##county## ] {
+      [col_nr = ##number##] {
+        polygon-opacity: 0.6; 
+        line-width: 2;
+      }
+    }
+  }
+</script>
+{/literal}
+<link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v2/themes/css/cartodb.css" />
+<script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<script src="//libs.cartocdn.com/cartodb.js/v2/cartodb.js"></script>
 <div style="float:left; font-size: 83%">
   <a href="?cid=23&colegiul={$college_name|replace:' ':'+'|lower}">{$college_name}...</a></div>
 


### PR DESCRIPTION
Câteva observații preluate de la #74:

> - poți face zoom in cu un nivel? La orice colegiu am încercat, dacă fac zoom in o dată, tot încape foarte bine și este mult mai ușor de văzut exact care sunt limitele colegiului.
> - poți face contururile mai groase, cu un pixel sau doi?
> - poți înlocui și hărțile de pe paginile senatorilor și deputaților activi? Vezi http://hartapoliticii.ro/?name=ponta+victor+viorel, sub poză, este o hartă cu colegiul pe care îl reprezintă.
> - bănuiesc că putem schimba relativ ușor tipul hărții de dedesubt, în loc de satellite view să fie hartă desenată.
